### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,8 +284,8 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Transformation of Flat files into XML")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/cookbook/cookbook-flatfile-transform")
         def properties = asNode().appendNode("properties")
-        properties.appendNode("url", "https://interlok.adaptris.net/interlok-docs/cookbook-flatfile-transform.html")
         properties.appendNode("target", "3.9.0+")
         properties.appendNode("tags", "transform,flatfile")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

Fix the doc url

## Result

The pom has a correct doc url

## Testing

Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
