### PR TITLE
V4 - INTERLOK-4429 Allow to configure DocumentBuilderFactoryBuilder

### DIFF
--- a/src/main/java/com/adaptris/core/transform/flatfile/FlatfileTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/flatfile/FlatfileTransformService.java
@@ -22,6 +22,10 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.validation.Valid;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.apache.commons.lang3.BooleanUtils;
 
 import com.adaptris.annotation.AdapterComponent;
@@ -35,6 +39,7 @@ import com.adaptris.core.CoreConstants;
 import com.adaptris.core.CoreException;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.ServiceImp;
+import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 import com.adaptris.core.util.ExceptionHelper;
 import com.adaptris.transform.ff.FfTransform;
 import com.adaptris.transform.ff.Source;
@@ -64,6 +69,12 @@ public class FlatfileTransformService extends ServiceImp {
   private transient List<Source> cachedRules;
   private transient Source configuredRule;
   private transient TransformFramework tf;
+  /**
+   * Configuration for the XML transform file
+   */
+  @AdvancedConfig(rare = true)
+  @Valid
+  private DocumentBuilderFactoryBuilder xmlDocumentFactoryConfig;
   @AdvancedConfig
   @InputFieldDefault(value = "true")
   private Boolean cacheTransforms;
@@ -295,6 +306,24 @@ public class FlatfileTransformService extends ServiceImp {
    * @throws Exception on error.
    */
   protected TransformFramework createFramework() throws Exception {
-    return new FfTransform();
+    return new FfTransform(docBuilder());
   }
+  
+  public DocumentBuilderFactoryBuilder getXmlDocumentFactoryConfig() {
+    return xmlDocumentFactoryConfig;
+  }
+
+  public void setXmlDocumentFactoryConfig(DocumentBuilderFactoryBuilder xml) {
+    xmlDocumentFactoryConfig = xml;
+  }
+
+  DocumentBuilderFactoryBuilder documentFactoryBuilder() {
+    return DocumentBuilderFactoryBuilder.newInstanceIfNull(getXmlDocumentFactoryConfig());
+  }
+
+  private DocumentBuilder docBuilder() throws ParserConfigurationException {
+    DocumentBuilderFactoryBuilder docFactoryBuilder = documentFactoryBuilder();
+    return docFactoryBuilder.newDocumentBuilder(docFactoryBuilder.build());
+  }
+  
 }

--- a/src/main/java/com/adaptris/transform/ff/FfTransform.java
+++ b/src/main/java/com/adaptris/transform/ff/FfTransform.java
@@ -23,15 +23,12 @@ import java.net.URISyntaxException;
 import java.text.SimpleDateFormat;
 
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 
 import com.adaptris.core.util.Args;
-import com.adaptris.core.util.DocumentBuilderFactoryBuilder;
 
 /**
  * <p>Performs transformations of data where the source is a flat file.</p>
@@ -46,9 +43,8 @@ public class FfTransform extends TransformFramework {
       new SimpleDateFormat("':'yyMMdd':'hh.mm.ss':'");
 
 
-  public FfTransform() throws Exception {
-    super();
-    db = _getDocumentBuilder();
+  public FfTransform(DocumentBuilder db) throws Exception {
+    this.db = db;
     // db is used to parse rule into its optimised form
   }
 
@@ -148,7 +144,7 @@ public class FfTransform extends TransformFramework {
       log.debug("addRule() invoked: rule <" + rule + ">");
     }
 
-    super.ruleList.add(rule, new RootHandler(_optimiseRule(db, rule)));
+    ruleList.add(rule, new RootHandler(_optimiseRule(db, rule)));
   }
 
   // This functionality has deliberately been left out of
@@ -161,18 +157,11 @@ public class FfTransform extends TransformFramework {
     throw new RuntimeException("FfTransform: input has not been initialised");
   }
 
-  private Element _optimiseRule(DocumentBuilder db, Source rule)
+  private Element _optimiseRule(DocumentBuilder documentBuilder, Source rule)
       throws SAXException, IOException, URISyntaxException {
-    Document output = db.parse(rule.getInputSource());
+    Document output = documentBuilder.parse(rule.getInputSource());
     Element optimisedRule = output.getDocumentElement();
     return optimisedRule;
-  }
-
-  // The DocumentBuilder returned is used to parse the rule
-  // (passed to the transform method) into its optimised format.
-  private DocumentBuilder _getDocumentBuilder() throws ParserConfigurationException {
-    return DocumentBuilderFactoryBuilder.newInstance().withNamespaceAware(true)
-        .newDocumentBuilder(DocumentBuilderFactory.newInstance());
   }
 
 }

--- a/src/test/java/com/adaptris/core/transform/flatfile/FlatfileTransformTest.java
+++ b/src/test/java/com/adaptris/core/transform/flatfile/FlatfileTransformTest.java
@@ -38,6 +38,7 @@ import org.xml.sax.SAXParseException;
 
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.CoreConstants;
+import com.adaptris.core.CoreException;
 import com.adaptris.core.DefaultMessageFactory;
 import com.adaptris.core.ServiceException;
 import com.adaptris.core.lms.FileBackedMessageFactory;
@@ -52,6 +53,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
   private static final String ISO_8859_1 = "ISO-8859-1";
   private static final String UTF_8 = "UTF-8";
   static final String KEY_FF_TEST_DEFINITION = "FlatfileTransformService.stylesheet";
+  static final String KEY_FF_TEST_DEFINITION_WITH_DOCTYPE = "FlatfileTransformService.stylesheet-with-doctype";
   static final String KEY_FF_TEST_INPUT = "FlatfileTransformService.inputFile";
   static final String KEY_FF_TEST_INPUT_ISO = "FlatfileTransformService.inputFile_ISO_8859";
 
@@ -65,10 +67,8 @@ public class FlatfileTransformTest extends TransformServiceExample {
   // private static final String TEST_INPUT_DETAIL_2 = "DETField 2.01Field 2.02Field 2.0320110630Field 2.04400821";
   // private static final String TEST_INPUT_DETAIL_3 = "DETField 2.01Field 2.02Field 2.0320110630Field 2.04400821";
 
-  private static final String KEY_ISSUE_2661_INPUT =
-      "FlatfileTransformService.issue2661.input";
-  private static final String KEY_ISSUE_2661_DEFINITION =
-      "FlatfileTransformService.issue2661.definition";
+  private static final String KEY_ISSUE_2661_INPUT = "FlatfileTransformService.issue2661.input";
+  private static final String KEY_ISSUE_2661_DEFINITION = "FlatfileTransformService.issue2661.definition";
   private static final String ISSUE_2661_XPATH = "/root/segment_shipto_line/record_[1]/Street";
 
   // Get's HDR from the TEST_INPUT_HDR_LINE
@@ -81,6 +81,27 @@ public class FlatfileTransformTest extends TransformServiceExample {
   public void testDoService() throws Exception {
     AdaptrisMessage m = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_FF_TEST_INPUT));
     FlatfileTransformService service = createService();
+    execute(service, m);
+    assertXml(m);
+  }
+
+  @Test
+  public void testDoServiceWithDoctypeNotAllowed() throws Exception {
+    AdaptrisMessage m = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_FF_TEST_INPUT));
+    FlatfileTransformService service = createService();
+    service.setUrl(PROPERTIES.getProperty(KEY_FF_TEST_DEFINITION_WITH_DOCTYPE));
+    CoreException exception = assertThrows(CoreException.class, () -> execute(service, m));
+    assertTrue(exception.getCause() instanceof SAXParseException);
+  }
+
+  @Test
+  public void testDoServiceWithDoctypeAllowed() throws Exception {
+    AdaptrisMessage m = MessageHelper.createMessage(PROPERTIES.getProperty(KEY_FF_TEST_INPUT));
+    FlatfileTransformService service = createService();
+    DocumentBuilderFactoryBuilder docBuilderFactoryBuilder = new DocumentBuilderFactoryBuilder()
+        .addFeature("http://apache.org/xml/features/disallow-doctype-decl", false);
+    service.setXmlDocumentFactoryConfig(docBuilderFactoryBuilder);
+    service.setUrl(PROPERTIES.getProperty(KEY_FF_TEST_DEFINITION_WITH_DOCTYPE));
     execute(service, m);
     assertXml(m);
   }
@@ -124,8 +145,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
 
   @Test
   public void testDoServiceFileBackedMessage() throws Exception {
-    AdaptrisMessage m = MessageHelper.createMessage(new FileBackedMessageFactory(),
-        PROPERTIES.getProperty(KEY_FF_TEST_INPUT));
+    AdaptrisMessage m = MessageHelper.createMessage(new FileBackedMessageFactory(), PROPERTIES.getProperty(KEY_FF_TEST_INPUT));
     FlatfileTransformService service = createService();
     execute(service, m);
     assertXml(m);
@@ -140,7 +160,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
     try {
       execute(service, msg);
     } catch (ServiceException expected) {
-      ;
+
     }
   }
 
@@ -183,7 +203,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
     service.setAllowOverride(true);
     service.setCacheTransforms(true);
 
-    assertThrows(ServiceException.class, ()->{
+    assertThrows(ServiceException.class, () -> {
       execute(service, msg);
     });
   }
@@ -193,8 +213,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
     FlatfileTransformService service = createService();
     DefaultMessageFactory factory = new DefaultMessageFactory();
     factory.setDefaultCharEncoding(UTF_8);
-    AdaptrisMessage msg =
-        MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_FF_TEST_INPUT_ISO));
+    AdaptrisMessage msg = MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_FF_TEST_INPUT_ISO));
     execute(service, msg);
     Document doc = createDocument(msg);
     XPath xp = new XPath();
@@ -208,8 +227,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
     FlatfileTransformService service = createService();
     DefaultMessageFactory factory = new DefaultMessageFactory();
     factory.setDefaultCharEncoding(ISO_8859_1);
-    AdaptrisMessage msg =
-        MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_FF_TEST_INPUT_ISO));
+    AdaptrisMessage msg = MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_FF_TEST_INPUT_ISO));
     execute(service, msg);
     Document doc = createDocument(msg);
     XPath xp = new XPath();
@@ -224,8 +242,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
     service.setOutputMessageEncoding(UTF_8);
     DefaultMessageFactory factory = new DefaultMessageFactory();
     factory.setDefaultCharEncoding(ISO_8859_1);
-    AdaptrisMessage msg =
-        MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_ISSUE_2661_INPUT));
+    AdaptrisMessage msg = MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_ISSUE_2661_INPUT));
 
     execute(service, msg);
     String srcValue = createExpectedValueFor2661();
@@ -243,8 +260,7 @@ public class FlatfileTransformTest extends TransformServiceExample {
     service.setUrl(PROPERTIES.getProperty(KEY_ISSUE_2661_DEFINITION));
     DefaultMessageFactory factory = new DefaultMessageFactory();
     factory.setDefaultCharEncoding(ISO_8859_1);
-    AdaptrisMessage msg =
-        MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_ISSUE_2661_INPUT));
+    AdaptrisMessage msg = MessageHelper.createMessage(factory, PROPERTIES.getProperty(KEY_ISSUE_2661_INPUT));
 
     execute(service, msg);
     createExpectedValueFor2661();

--- a/src/test/java/com/adaptris/core/transform/flatfile/FlatfileTransformTest.java
+++ b/src/test/java/com/adaptris/core/transform/flatfile/FlatfileTransformTest.java
@@ -19,6 +19,7 @@ package com.adaptris.core.transform.flatfile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/test/java/com/adaptris/transform/ff/TransformFrameworkTest.java
+++ b/src/test/java/com/adaptris/transform/ff/TransformFrameworkTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2018 Adaptris Ltd.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,6 +37,7 @@ public class TransformFrameworkTest extends TransformFramework {
     TransformFramework tf = new TransformFrameworkTest();
     Source source = new Source(new StringReader("hello"));
     tf.addRule(source);
+    assertEquals(1, tf.getNumRules());
     tf.removeRule(source);
     assertEquals(0, tf.getNumRules());
     tf.addRule(source);

--- a/src/test/resources/transform/ff.definition-with-doctype.xml
+++ b/src/test/resources/transform/ff.definition-with-doctype.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<!DOCTYPE adapter [
+<!ENTITY rec_id 'HDR'>
+]>
+<root encoding="iso-8859-1">
+<segment name="Document">
+  <segment name="Header">
+  <record length="0" separator="\n" rec_id="&rec_id;" rec_id_start="1" rec_id_len="3" field_sep="" repetitions="0">
+    <field name = "RecordType" length = "3" separator = ""/>
+    <field name = "SourceCode" length = "3" separator = ""/>
+    <field name = "RunDate" length = "8" separator = ""/>
+    <field name = "Title" length = "16" separator = ""/>
+    <field name = "SourceDescription" length = "7" separator = ""/>
+    <field name = "DestDescription" length = "17" separator = ""/>
+    <field name = "Filler" length = "10" separator = ""/>
+  </record>
+  </segment>
+  <segment name="Details">
+    <record length="0" separator="\n" rec_id="DET" rec_id_start="1" rec_id_len="3" field_sep="" repetitions="0">
+      <field name = "RecordType" length = "3" separator = ""/>
+      <field name = "FieldOne" length = "12" separator = ""/>
+      <field name = "FieldTwo" length = "11" separator = ""/>
+      <field name = "FieldThree" length = "14" separator = ""/>
+      <field name = "CompletionDate" length = "8" separator = ""/>
+      <field name = "FieldFour" length = "12" separator = ""/>
+      <field name = "Filler" length = "6" separator = ""/>
+    </record>
+  </segment>
+  <segment name="Trailer">
+    <record length="0" separator="\n" rec_id="TRL" rec_id_start="1" rec_id_len="3" field_sep="" repetitions="0">
+      <field name = "RecordType" length = "3" separator = ""/>
+      <field name = "Total" length = "8" separator = ""/>
+      <field name = "Filler" length = "53" separator = ""/>
+    </record>
+  </segment>
+</segment>
+</root>

--- a/src/test/resources/unit-tests.properties.template
+++ b/src/test/resources/unit-tests.properties.template
@@ -4,6 +4,7 @@ ProducerCase.baseDir=@BUILD_DIR@/examples/producers
 WorkflowCase.baseDir=@BUILD_DIR@/examples/workflows
 
 FlatfileTransformService.stylesheet=file:///@BASE_DIR@/src/test/resources/transform/ff.definition.xml
+FlatfileTransformService.stylesheet-with-doctype=file:///@BASE_DIR@/src/test/resources/transform/ff.definition-with-doctype.xml
 FlatfileTransformService.inputFile=@BASE_DIR@/src/test/resources/transform/ff.input.txt
 FlatfileTransformService.inputFile_ISO_8859=@BASE_DIR@/src/test/resources/transform/ff.input.iso8859.txt
 FlatfileTransformService.issue2661.input=@BASE_DIR@/src/test/resources/transform/issue2661.csv


### PR DESCRIPTION
## Motivation

If the xml transform has a doctype it cannot be used

## Modification

Allow to configure DocumentBuilderFactoryBuilder in the FlatFileTransformService to be able to override default disabled features.

## PR Checklist

- [x] been self-reviewed.

## Result

We can now configure the DocumentBuilderFactory

## Testing

Use the jar built from this PR.

A transform with a doctype like:

```xml
<?xml version="1.0"?>
<!DOCTYPE adapter [
<!ENTITY rec_id 'HDR'>
]>
<root encoding="iso-8859-1">
<segment name="Document">
  <segment name="Header">
  <record length="0" separator="\n" rec_id="&rec_id;" rec_id_start="1" rec_id_len="3" field_sep="" repetitions="0">
    <field name = "RecordType" length = "3" separator = ""/>
    <field name = "SourceCode" length = "3" separator = ""/>
    <field name = "RunDate" length = "8" separator = ""/>
    <field name = "Title" length = "16" separator = ""/>
    <field name = "SourceDescription" length = "7" separator = ""/>
    <field name = "DestDescription" length = "17" separator = ""/>
    <field name = "Filler" length = "10" separator = ""/>
  </record>
  </segment>
  <segment name="Details">
    <record length="0" separator="\n" rec_id="DET" rec_id_start="1" rec_id_len="3" field_sep="" repetitions="0">
      <field name = "RecordType" length = "3" separator = ""/>
      <field name = "FieldOne" length = "12" separator = ""/>
      <field name = "FieldTwo" length = "11" separator = ""/>
      <field name = "FieldThree" length = "14" separator = ""/>
      <field name = "CompletionDate" length = "8" separator = ""/>
      <field name = "FieldFour" length = "12" separator = ""/>
      <field name = "Filler" length = "6" separator = ""/>
    </record>
  </segment>
  <segment name="Trailer">
    <record length="0" separator="\n" rec_id="TRL" rec_id_start="1" rec_id_len="3" field_sep="" repetitions="0">
      <field name = "RecordType" length = "3" separator = ""/>
      <field name = "Total" length = "8" separator = ""/>
      <field name = "Filler" length = "53" separator = ""/>
    </record>
  </segment>
</segment>
</root>
```
With an input like:

```
HDRSRC20110601THE TITLE OF DOCSrcDescDestinationDesc  1234567890  
DETField   1.01Field  1.02Field     1.0320110630Field   1.04400821
DETField   2.01Field  2.02Field     2.0320110730Field   2.04400821
DETField   3.01Field  3.02Field     3.0320110830Field   3.04400821
TRL00000005                                                       
```
And a service config like:

```xml
<flat-file-transform-service>
  <unique-id>flat-file-transform-service</unique-id>
  <url>file:///./transform/ff.definition-with-doctype.xml</url>
  <metadata-key>transformurl</metadata-key>
  <xml-document-factory-config>
    <features>
      <key-value-pair>
        <key>http://apache.org/xml/features/disallow-doctype-decl</key>
        <value>false</value>
      </key-value-pair>
    </features>
  </xml-document-factory-config>
</flat-file-transform-service>
```
It should work

If you remove `xml-document-factory-config` it will faill