### PR TITLE
Added null check for output message encoding based writer

### DIFF
--- a/src/main/java/com/adaptris/core/transform/flatfile/FlatfileTransformService.java
+++ b/src/main/java/com/adaptris/core/transform/flatfile/FlatfileTransformService.java
@@ -137,7 +137,7 @@ public class FlatfileTransformService extends ServiceImp {
   @Override
   public final void doService(AdaptrisMessage msg) throws ServiceException {
 
-    try (Reader in = msg.getReader(); Writer output = msg.getWriter(getOutputMessageEncoding())) {
+    try (Reader in = msg.getReader(); Writer output = (getOutputMessageEncoding() != null) ? msg.getWriter(getOutputMessageEncoding()) : msg.getWriter()) {
       Source src = new Source(in);
       Target dst = new Target(output);
 


### PR DESCRIPTION
## Motivation

When using FlatFileTransformService, message writer erroneously  introduces payload attribute of null into Adaptris message if no output message encoding is present.

## Modification

Call correct Adaptris Message getWriter Api when the nullable output message encoding is null.

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [x] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [x] Checked that javadoc generation doesn't report errors
- [x] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [x] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

Adaptris Message getWriter Api without a parameter is called, instead of getWriter Api with null as parameter

## Testing

It can be tested by using Flat file Transform Service without any message encoding explicitly mentioned like below - 

<flat-file-transform-service>
       <unique-id>execute-flat-file-transform</unique-id>
       <metadata-key>pn.processing.worker.transform.ff-url</metadata-key>
       <allow-override>true</allow-override>
</flat-file-transform-service>
